### PR TITLE
Handle missing QuestTome to prevent null reference crash

### DIFF
--- a/Data/Scripts/Quests/Major/QuestTome.cs
+++ b/Data/Scripts/Quests/Major/QuestTome.cs
@@ -946,8 +946,16 @@ namespace Server.Items
 
         public static bool FoundItem(Mobile player, int type, MajorItemOnCorpse chest)
         {
-            Item item = player.Backpack.FindItemByType(typeof(QuestTome));
-            QuestTome book = (QuestTome)item;
+            if (player == null || player.Backpack == null)
+            {
+                return false;
+            }
+
+            QuestTome book = player.Backpack.FindItemByType(typeof(QuestTome)) as QuestTome;
+            if (book == null)
+            {
+                return false;
+            }
 
             if (
                 type == book.QuestTomeType


### PR DESCRIPTION
## Summary
- Guard against null mobile or backpack
- Avoid NullReferenceException when player lacks QuestTome

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_689f73ff721483218b20400c4b0766f0